### PR TITLE
Fixed return value of pure method is not used in AddClaims method.

### DIFF
--- a/Fiver.Security.Bearer.Helpers/JwtTokenBuilder.cs
+++ b/Fiver.Security.Bearer.Helpers/JwtTokenBuilder.cs
@@ -48,7 +48,7 @@ namespace Fiver.Security.Bearer.Helpers
 
         public JwtTokenBuilder AddClaims(Dictionary<string, string> claims)
         {
-            this.claims.Union(claims);
+            this.claims = this.claims.Union(claims).ToDictionary(k => k.Key, v => v.Value);
             return this;
         }
 


### PR DESCRIPTION
Fixes https://github.com/TahirNaushad/Fiver.Security.Bearer/issues/2.